### PR TITLE
Memoize ConfigFileReader#config_file_exists? method

### DIFF
--- a/lib/runger_release_assistant/config_file_reader.rb
+++ b/lib/runger_release_assistant/config_file_reader.rb
@@ -19,6 +19,7 @@ class RungerReleaseAssistant::ConfigFileReader
     "#{ENV.fetch('PWD')}/.release_assistant.yml"
   end
 
+  memo_wise \
   def config_file_exists?
     File.exist?(config_file_path)
   end


### PR DESCRIPTION
I'm really just trying to make a change to test something (bundler gem cacheing in the GitHub Action). This seemed like a good/fine change to make. Even though this method probably will only ever be called once, I still like to memoize when the method is something that I want memoized.