### PR TITLE
Add bin/release as a symlink pointing to exe/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,1 @@
+../exe/release


### PR DESCRIPTION
This way, we can use the gem to release itself, using the same `bin/release` path that will be used in other projects that use this gem.