### PR TITLE
Run 'main' (not 'safe') after releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- **BREAKING:** Run `main` (not `safe`) after releasing.
 
 ## v0.14.0 (2024-12-31)
 - Ensure we are on the primary branch when releasing

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ versions via git/GitHub and (optionally) via RubyGems.
 
 This gem is somewhat customized and built specifically for my (David Runger's)
 custom and idiosyncratic workflow. For example, after releasing, this gem will
-automatically execute a `safe` command, if one is present on the machine. You
-might not want this behavior (if you have a `safe` command that you _don't_ want
+automatically execute a `main` command, if one is present on the machine. You
+might not want this behavior (if you have a `main` command that you _don't_ want
 to be invoked after a release).
 
 Realistically speaking, though, this gem actually probably could be used by

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -98,7 +98,7 @@ class RungerReleaseAssistant
     ERROR_LOG
     restore_and_abort(exit_code: 1)
   else
-    run_safe_command
+    run_main_command
     switch_to_initial_branch
   end
 
@@ -228,9 +228,9 @@ class RungerReleaseAssistant
     execute_command('bundle exec rake release', show_system_output: true)
   end
 
-  def run_safe_command
-    if system('which safe')
-      execute_command('safe', clear_bundler_context: true)
+  def run_main_command
+    if system('which main')
+      execute_command('main', clear_bundler_context: true)
     end
   end
 


### PR DESCRIPTION
I have renamed my `safe` script to `main` (and changed its functionality accordingly).

Ref: https://github.com/davidrunger/dotfiles/pull/431/files#diff-ac5ec40d575670d1709393d41068b41d2f238c6edb4c86ca9ec636b4d4c98094