### PR TITLE
[spec_helper] Require default gems in addition to test gems

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-Bundler.require(:test)
-require_relative '../lib/runger_release_assistant.rb'
+Bundler.require(:default, :test)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Since our default gems include `gemspec` (and, indeed, consist only of that), we can remove `require_relative '../lib/runger_release_assistant.rb'`.