### PR TITLE
Add 'rake' as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Add `rake` as a dependency.
 
 ## v2.0.0 (2025-02-05)
 - **BREAKING:** Source post-release command from `~/code/dotfiles` [`runger-config`](https://github.com/davidrunger/dotfiles/blob/cd02495fb2ad742cc1e85cc65aea5ff711485981/crystal-programs/runger-config.cr), rather than always running `main` command (if available).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ PATH
       activesupport (>= 6)
       memo_wise (>= 1.7)
       rainbow (>= 3.0)
+      rake (>= 13.2.1)
       slop (~> 4.8)
 
 GEM

--- a/runger_release_assistant.gemspec
+++ b/runger_release_assistant.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('activesupport', '>= 6')
   spec.add_dependency('memo_wise', '>= 1.7')
   spec.add_dependency('rainbow', '>= 3.0')
+  spec.add_dependency('rake', '>= 13.2.1')
   spec.add_dependency('slop', '~> 4.8')
 
   required_ruby_version = File.read('.ruby-version').rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')


### PR DESCRIPTION
We use it here: https://github.com/davidrunger/runger_release_assistant/blob/acbc8467dc40b05e7ca6bbb36463af72d3af1ce2/lib/runger_release_assistant.rb#L217 .