### PR TITLE
Stop creating a new alpha version after release [REL-6]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,5 @@ jobs:
       run: bin/rubocop --format clang
     - name: Run RSpec tests
       run: bin/rspec --format progress
-    - name: Ensure alpha version
-      run: grep alpha lib/runger_release_assistant/version.rb
     - name: Ensure no git diff
       run: git diff --exit-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Stop creating a new alpha version after release.
 
 ## v2.0.1 (2025-03-19)
 - Add `rake` as a dependency.


### PR DESCRIPTION
I think it's fine for anyone who is using the main branch or whatever to just have the same version number that the released gem has.

Creating the alpha versions is git noise and code complexity that I think is not worth it.

One minor downside of this change is that now the changelog for the released tag will have an "## Unreleased / [no unreleased changes yet]" section. But, it's technically true, at the time of the release, that there are no unreleased changes. So it's just a small bit of extra clutter in the changelog. I think it's fine.