### PR TITLE
Push to git even if pushing to RubyGems is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Stop creating a new alpha version after release.
+- Push to git even if pushing to RubyGems is not enabled.
 
 ## v2.0.1 (2025-03-19)
 - Add `rake` as a dependency.

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -81,7 +81,12 @@ class RungerReleaseAssistant
     bundle_install
     commit_changes(message: "Prepare to release v#{next_version}")
     create_tag
-    push_to_rubygems_and_git if @options[:rubygems] && @options[:git]
+
+    if @options[:rubygems] && @options[:git]
+      push_to_rubygems_and_git
+    elsif @options[:git]
+      push_to_git
+    end
   rescue => error
     logger.error(<<~ERROR_LOG)
       \n


### PR DESCRIPTION
This is a follow-up to #576 to introduce a bug introduced therein where I think that we would not push to git after a release for projects only using git (not RubyGems).