### PR TITLE
Add '-a' flag to 'git tag' command to be clear that it's annotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Add `-a` flag to `git tag` command to be clear that the tag is annotated.
 
 ## v3.1.0 (2025-03-20)
 - Put tag name before tag message in git command.

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -187,7 +187,7 @@ class RungerReleaseAssistant
   end
 
   def create_tag
-    execute_command(%(git tag '#{git_tag_version(next_version)}' -m 'Version #{next_version}'))
+    execute_command(%(git tag -a '#{git_tag_version(next_version)}' -m 'Version #{next_version}'))
   end
 
   def git_tag_version(version)


### PR DESCRIPTION
The `-m "<message>"` option implicitly makes it an annotated flag, but let's be explicit by also using an `-a` flag.