### PR TITLE
Always push to git (and don't respect any `git` config option)

### DIFF
--- a/.release_assistant.yml
+++ b/.release_assistant.yml
@@ -1,3 +1,2 @@
 ---
-git: true
 rubygems: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Always push to git, rather than requiring `git: true` to be specified in the config (or respecting at all a `git` option in the config).
 
 ## v3.2.0 (2025-03-20)
 - Add `-a` flag to `git tag` command to be clear that the tag is annotated.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Here is an example:
 
 ```yml
 ---
-git: true
 rubygems: false
 primary_branch: main
 ```
@@ -120,11 +119,7 @@ primary_branch: main
 The above example (more or less) illustrates the default values, so you don't
 need to create a config file, if those are the values that you want.
 
-Regarding the `primary_branch` option, `runger_release_assistant` will
-automatically detect as the "primary branch" any one of the following: `main`,
-`master`, or `trunk`. So, if one of those is the name of your primary branch,
-and if you also want `git: true` and `rubygems: false`, then you don't need to
-create a config file.
+Regarding the `primary_branch` option, `runger_release_assistant` will automatically detect as the "primary branch" any one of the following: `main`, `master`, or `trunk`. So, if one of those is the name of your primary branch, and if you also want `rubygems: false`, then you don't need to create a config file.
 
 ## Post-release command
 

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -43,7 +43,7 @@ class RungerReleaseAssistant
     end
   end
 
-  DEFAULT_OPTIONS = { git: true, rubygems: false }.freeze
+  DEFAULT_OPTIONS = { rubygems: false }.freeze
 
   class << self
     def define_slop_options(options)
@@ -53,9 +53,8 @@ class RungerReleaseAssistant
     end
   end
 
-  def initialize(options)
+  def initialize(options = {}) # rubocop:disable Style/OptionHash
     @options = options
-    validate_options!
     logger.debug("Running release with options #{@options}")
   end
 
@@ -94,12 +93,6 @@ class RungerReleaseAssistant
   end
 
   private
-
-  def validate_options!
-    if @options[:git] != true
-      fail('The `git` configuration option must be `true`')
-    end
-  end
 
   def ensure_on_main_branch
     if current_branch != primary_branch
@@ -199,21 +192,19 @@ class RungerReleaseAssistant
       push_to_rubygems
     end
 
-    if @options[:git]
-      push_to_git
-    end
-  end
-
-  def push_to_git
-    logger.debug('Pushing to git remote')
-    execute_command('git push')
-    execute_command('git push --tags')
+    push_to_git
   end
 
   def push_to_rubygems
     logger.debug('Pushing to RubyGems and git')
     # Always show system output because 2FA should be enabled, which requires user to see the prompt
     execute_command('bundle exec rake release', show_system_output: true)
+  end
+
+  def push_to_git
+    logger.debug('Pushing to git remote')
+    execute_command('git push')
+    execute_command('git push --tags')
   end
 
   def run_post_release_command

--- a/spec/runger_release_assistant_spec.rb
+++ b/spec/runger_release_assistant_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RungerReleaseAssistant do
-  subject(:runger_release_assistant) { RungerReleaseAssistant.new(options) }
-
-  let(:options) { { git: true } }
+  subject(:runger_release_assistant) { RungerReleaseAssistant.new }
 
   describe '#primary_branch' do
     subject(:primary_branch) { runger_release_assistant.send(:primary_branch) }


### PR DESCRIPTION
Rather than requiring `git: true` in the config, let's just assume that we should always push to git.