### PR TITLE
Support optional tag prefix [REL-5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Support optional tag prefix (via a `tag_prefix` in `.release_assistant.yml`).
 
 ## v4.0.0 (2025-03-20)
 - **BREAKING:** Always push to git, rather than requiring `git: true` to be specified in the config (or respecting at all a `git` option in the config).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ you'd also like to release the gem via RubyGems, then create a `.release_assista
 executing `release --init`. Within that file, modify the default `rubygems: false` option to
 `rubygems: true`.
 
+## Tag prefix
+
+By default, Git tags are created like `v1.0.0`. If you would like to prefix the git tag with any additional content, you may specify a `tag_prefix` in `.release_assistant.yml`, such as:
+
+```yml
+tag_prefix: gem/
+```
+
+This example would generate tags in the form `gem/v1.0.0`.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -180,11 +180,11 @@ class RungerReleaseAssistant
   end
 
   def create_tag
-    execute_command(%(git tag -a '#{git_tag_version(next_version)}' -m 'Version #{next_version}'))
+    execute_command(%(git tag -a '#{git_tag(next_version)}' -m 'Version #{next_version}'))
   end
 
-  def git_tag_version(version)
-    "v#{version}"
+  def git_tag(version)
+    "#{@options[:tag_prefix]}v#{version}"
   end
 
   def push_to_rubygems_and_or_git
@@ -275,7 +275,7 @@ class RungerReleaseAssistant
       { 'DELTA_PAGER' => 'cat' },
       'git',
       'diff',
-      "#{git_tag_version(current_released_version)}...",
+      "#{latest_tag}...",
     )
   end
 
@@ -302,8 +302,13 @@ class RungerReleaseAssistant
   end
 
   memo_wise \
+  def latest_tag
+    `git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1`.rstrip
+  end
+
+  memo_wise \
   def current_released_version
-    `git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1`.delete_prefix('v').rstrip
+    latest_tag.match(/v(\d.*)$/)&.[](1)
   end
 
   memo_wise \


### PR DESCRIPTION
https://chatgpt.com/c/67dc2f0b-0c90-8007-b5f4-a008fb70b750

For `vue_rails_model_explorer`, I want to tag the gem releases with a `gem/` prefix and tag the NPM releases with an `npm/` prefix. This change will make the `gem/` prefix possible.