### PR TITLE
Fix NoMethodError printing nil in blue if there is no latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+### Fixed
+- Fix `NoMethodError` trying to print `nil` in blue if there is no latest tag.
 
 ## v4.1.0 (2025-03-20)
 - Support optional tag prefix (via a `tag_prefix` in `.release_assistant.yml`).

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -102,7 +102,7 @@ class RungerReleaseAssistant
 
   def print_release_info
     logger.info("You are running the release process with options #{@options.to_h}.")
-    logger.info("Current released version is #{current_released_version.blue}.")
+    logger.info("Current released version is #{(current_released_version || '[none]').blue}.")
     logger.info("Next version will be #{next_version.green}.")
 
     print_changelog_content_of_upcoming_release


### PR DESCRIPTION
```
❯ bin/release --type minor --debug --show-system-output
[runger_release_assistant] Running release with options {rubygems: true, tag_prefix: "gem/", type: "minor", debug: true, show_system_output: true}
[runger_release_assistant] You are running the release process with options {rubygems: true, tag_prefix: "gem/", type: "minor", debug: true, show_system_output: true}.
[runger_release_assistant] 

NoMethodError: undefined method 'blue' for nil
/home/david/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/runger_release_assistant-4.1.0/lib/runger_release_assistant.rb:105:in 'RungerReleaseAssistant#print_release_info'
/home/david/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/runger_release_assistant-4.1.0/lib/runger_release_assistant.rb:74:in 'RungerReleaseAssistant#run_release'
/home/david/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/runger_release_assistant-4.1.0/exe/release:51:in '<top (required)>'
bin/release:27:in 'Kernel#load'
bin/release:27:in '<main>'
```