### PR TITLE
[readme] Add info about telling bundler about a tag prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,17 @@ By default, Git tags are created like `v1.0.0`. If you would like to prefix the 
 tag_prefix: gem/
 ```
 
+You most also provide this to bundler by putting something like the following in your `Rakefile`:
+
+```rb
+require 'bundler/gem_tasks'
+require 'runger_release_assistant'
+Bundler::GemHelper.tag_prefix = RungerReleaseAssistant.new.tag_prefix
+```
+
 This example would generate tags in the form `gem/v1.0.0`.
+
+Note that all version numbers in git tags will be prefixed with at least a `v`. The `tag_prefix` option is to specify an additional prefix, in addition to the `v`.
 
 ## Development
 

--- a/exe/release
+++ b/exe/release
@@ -42,10 +42,4 @@ slop_options =
     end
   end
 
-config_file_options = RungerReleaseAssistant::ConfigFileReader.new.options_hash
-
-RungerReleaseAssistant.new(
-  RungerReleaseAssistant::DEFAULT_OPTIONS.
-    merge(config_file_options).
-    merge(slop_options.to_h),
-).run_release
+RungerReleaseAssistant.new(slop_options.to_h).run_release


### PR DESCRIPTION
Currently, in addition to this gem creating a tag with the prefix (when one is specified), bundler also creates a tag without the prefix. If users make the mentioned change in their `Rakefile`, then bundler will realize that we have already the desired tag, and it shouldn't create one without the specified prefix.

Also, delete the appropriate tag, in the event that there is an error and if we are using a tag prefix.

Also, include the current and next tag in the pre-release summary info.