### PR TITLE
[gemspec] Work around dependabot bug by using 'File.public_send'

### DIFF
--- a/runger_release_assistant.gemspec
+++ b/runger_release_assistant.gemspec
@@ -40,6 +40,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rake', '>= 13.2.1')
   spec.add_dependency('slop', '~> 4.8')
 
-  required_ruby_version = File.read('.ruby-version').rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')
+  # HACK: Using public_send rather than read works around a Dependabot bug.
+  # rubocop:disable Style/SendWithLiteralMethodName
+  required_ruby_version =
+    File.public_send(:read, '.ruby-version').
+      rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')
+  # rubocop:enable Style/SendWithLiteralMethodName
   spec.required_ruby_version = ">= #{required_ruby_version}"
 end


### PR DESCRIPTION
... rather than `File.read` to read the Ruby version from the `.ruby-version` file.

The issue is that Dependabot overwrites all `File.read` content in the gemspec with the gem's own version number (I guess on the assumption that `File.read` might be used to read the value of `spec.version`, i.e. the gem's own version number, from a version file). I think that basically happens here: https://github.com/dependabot/dependabot-core/blob/42d95a29/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb/#L369-L371 .

Copied from https://github.com/davidrunger/runger_style/pull/521 .