### PR TITLE
Only use the RubyGems bundler release sub-task that we need [REL-7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Only use the RubyGems bundler release rake sub-tasks needed to push to RubyGems.
 
 ## v4.2.1 (2025-03-20)
 ### Docs

--- a/README.md
+++ b/README.md
@@ -141,17 +141,9 @@ By default, Git tags are created like `v1.0.0`. If you would like to prefix the 
 tag_prefix: gem/
 ```
 
-You must also provide this to bundler by putting something like the following in your `Rakefile`:
-
-```rb
-require 'bundler/gem_tasks'
-require 'runger_release_assistant'
-Bundler::GemHelper.tag_prefix = RungerReleaseAssistant.new.tag_prefix
-```
-
 This example would generate tags in the form `gem/v1.0.0`.
 
-Note that all version numbers in git tags will be prefixed with at least a `v`. The `tag_prefix` option is to specify an additional prefix, in addition to the `v`.
+Note that all version numbers in git tags will be prefixed with at least a `v`. The `tag_prefix` option is to specify another prefix, in addition to the `v`.
 
 ## Development
 

--- a/lib/runger_release_assistant.rb
+++ b/lib/runger_release_assistant.rb
@@ -221,8 +221,11 @@ class RungerReleaseAssistant
 
   def push_to_rubygems
     logger.debug('Pushing to RubyGems and git')
-    # Always show system output because 2FA should be enabled, which requires user to see the prompt
-    execute_command('bundle exec rake release', show_system_output: true)
+    # Show system output because 2FA should be enabled, which requires the user to see the prompt.
+    execute_command(
+      'bundle exec rake build release:guard_clean release:rubygem_push',
+      show_system_output: true,
+    )
   end
 
   def push_to_git


### PR DESCRIPTION
This way, users won’t have to specify the git tag prefix in their Rakefile.